### PR TITLE
Add Recording API

### DIFF
--- a/android/src/main/java/com/reactnative/googlefit/GoogleFitManager.java
+++ b/android/src/main/java/com/reactnative/googlefit/GoogleFitManager.java
@@ -53,6 +53,7 @@ public class GoogleFitManager implements
     private CalorieHistory calorieHistory;
     private StepCounter mStepCounter;
     private StepSensor stepSensor;
+    private RecordingApi recordingApi;
 
     private static final String TAG = "RNGoogleFit";
 
@@ -69,11 +70,16 @@ public class GoogleFitManager implements
         this.weightsHistory = new WeightsHistory(mReactContext, this);
         this.distanceHistory = new DistanceHistory(mReactContext, this);
         this.calorieHistory = new CalorieHistory(mReactContext, this);
+        this.recordingApi = new RecordingApi(mReactContext, this);
         //        this.stepSensor = new StepSensor(mReactContext, activity);
     }
 
     public GoogleApiClient getGoogleApiClient() {
         return mApiClient;
+    }
+
+    public RecordingApi getRecordingApi() {
+        return recordingApi;
     }
 
     public StepCounter getStepCounter() {

--- a/android/src/main/java/com/reactnative/googlefit/GoogleFitManager.java
+++ b/android/src/main/java/com/reactnative/googlefit/GoogleFitManager.java
@@ -109,10 +109,10 @@ public class GoogleFitManager implements
 
     public void authorize(@Nullable final Callback errorCallback, @Nullable final Callback successCallback) {
 
-        //Log.i(TAG, "Authorizing");
         mApiClient = new GoogleApiClient.Builder(mReactContext.getApplicationContext())
                 .addApi(Fitness.SENSORS_API)
                 .addApi(Fitness.HISTORY_API)
+                .addApi(Fitness.RECORDING_API)
                 .addScope(new Scope(Scopes.FITNESS_ACTIVITY_READ))
                 .addScope(new Scope(Scopes.FITNESS_BODY_READ_WRITE))
                 .addScope(new Scope(Scopes.FITNESS_LOCATION_READ))
@@ -143,12 +143,14 @@ public class GoogleFitManager implements
                     new GoogleApiClient.OnConnectionFailedListener() {
                         @Override
                         public void onConnectionFailed(@NonNull ConnectionResult connectionResult) {
+
+                            // if (errorCallback != null) {
+                            //    errorCallback.invoke("Failed Authorization Mgr");
+                            // }
+
                             Log.i(TAG, "Authorization - Failed Authorization Mgr:" + connectionResult);
                             if (mAuthInProgress) {
                                 Log.i(TAG, "Authorization - Already attempting to resolve an error.");
-                                //if (errorCallback != null) {
-                                //    errorCallback.invoke("Failed Authorization Mgr");
-                                //}
                             } else if (connectionResult.hasResolution()) {
                                 try {
                                     mAuthInProgress = true;

--- a/android/src/main/java/com/reactnative/googlefit/GoogleFitModule.java
+++ b/android/src/main/java/com/reactnative/googlefit/GoogleFitModule.java
@@ -88,6 +88,11 @@ LifecycleEventListener {
     }
     
     @ReactMethod
+    public void startFitnessRecording() {
+        mGoogleFitManager.getRecordingApi().subscribe();
+    }
+
+    @ReactMethod
     public void observeSteps() {
         mGoogleFitManager.getStepCounter().findFitnessDataSources();
     }

--- a/android/src/main/java/com/reactnative/googlefit/GoogleFitModule.java
+++ b/android/src/main/java/com/reactnative/googlefit/GoogleFitModule.java
@@ -36,7 +36,6 @@ LifecycleEventListener {
     
     public GoogleFitModule(ReactApplicationContext reactContext) {
         super(reactContext);
-        
         this.mReactContext = reactContext;
     }
     

--- a/android/src/main/java/com/reactnative/googlefit/RecordingApi.java
+++ b/android/src/main/java/com/reactnative/googlefit/RecordingApi.java
@@ -11,7 +11,7 @@
 
 package com.reactnative.googlefit;
 
-import com.rfs.GoogleFitManager;
+import com.reactnative.googlefit.GoogleFitManager;
 
 import com.facebook.react.bridge.ReactContext;
 import android.util.Log;
@@ -23,6 +23,7 @@ import com.google.android.gms.common.api.ResultCallback;
 import com.google.android.gms.fitness.data.DataType;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 
@@ -40,65 +41,57 @@ public class RecordingApi {
 
     private static final String TAG = "RecordingApi";
 
-    public FitnessRecord (ReactContext reactContext, GoogleFitManager googleFitManager) {
+    public RecordingApi (ReactContext reactContext, GoogleFitManager googleFitManager) {
 
         this.reactContext = reactContext;
         this.googleFitManager = googleFitManager;
 
     }
 
-    // This function could take an array as parameters and subscribe to each fitness data type provided
-    public ReadableArray subscribe () {
-
-        final WritableArray result = Arguments.createArray();
+    public void subscribe () {
 
         Fitness.RecordingApi.subscribe(googleFitManager.getGoogleApiClient(), DataType.TYPE_STEP_COUNT_CUMULATIVE)
             .setResultCallback(new ResultCallback <Status> () {
 
                 @Override
                 public void onResult(Status status) {
+
+                    WritableMap map = Arguments.createMap();
+
                     if (status.isSuccess()) {
-                            if (status.getStatusCode()
-                                    == FitnessStatusCodes.SUCCESS_ALREADY_SUBSCRIBED) {
-                                Log.i(TAG, "Existing subscription for activity detected.");
-                                sendEvent(reactContext, "RecordingSuccess", null);
-                            } else {
-                                Log.i(TAG, "Successfully subscribed!");
-                                sendEvent(reactContext, "RecordingSuccess", null);
-                            }
-                        } else {
-                            Log.i(TAG, "There was a problem subscribing.");
-                            sendEvent(reactContext, "RecordingError", null);
-                        }
+                        map.putBoolean("recording", true);
+                        Log.i(TAG, "RecordingAPI - Connected");
+                        sendEvent(reactContext, "STEP_RECORDING", map);
+
+                    } else {
+                        map.putBoolean("recording", false);
+                        Log.i(TAG, "RecordingAPI - Error connecting");
+                        sendEvent(reactContext, "STEP_RECORDING", map);
+                    }
                 }
             });
-        Fitness.RecordingApi.subscribe(googleFitManager.getGoogleApiClient(), DataType.TYPE_DISTANCE_DELTA)
+            Fitness.RecordingApi.subscribe(googleFitManager.getGoogleApiClient(), DataType.TYPE_DISTANCE_DELTA)
             .setResultCallback(new ResultCallback <Status> () {
 
                 @Override
                 public void onResult(Status status) {
 
+                    WritableMap map = Arguments.createMap();
+
                     if (status.isSuccess()) {
-                            if (status.getStatusCode()
-                                    == FitnessStatusCodes.SUCCESS_ALREADY_SUBSCRIBED) {
-                                Log.i(TAG, "Existing subscription for activity detected.");
-                                sendEvent(reactContext, "DistanceRecordingSuccess", null);
-                            } else {
-                                Log.i(TAG, "Successfully subscribed!");
-                                sendEvent(reactContext, "DistanceRecordingSuccess", null);
-                            }
-                        } else {
-                            Log.i(TAG, "There was a problem subscribing.");
-                            sendEvent(reactContext, "DistanceRecordFail", null);
-                        }
+                        map.putBoolean("recording", true);
+                        Log.i(TAG, "RecordingAPI - Connected");
+                        sendEvent(reactContext, "DISTANCE_RECORDING", map);
+
+                    } else {
+                        map.putBoolean("recording", false);
+                        Log.i(TAG, "RecordingAPI - Error connecting");
+                        sendEvent(reactContext, "DISTANCE_RECORDING", map);
+                    }
                 }
             });
-
-        // Could be a void function instead of returning this string - success/error messages 
-        // are emitted as events 
-        result.pushString("Success :)");
-        return result;
     }
+
 
     private void sendEvent(ReactContext reactContext,
         String eventName, @Nullable WritableMap params) {

--- a/android/src/main/java/com/reactnative/googlefit/RecordingApi.java
+++ b/android/src/main/java/com/reactnative/googlefit/RecordingApi.java
@@ -1,0 +1,109 @@
+/**
+ * Copyright (c) 2017-present, Stanislav Doskalenko - doskalenko.s@gmail.com
+ * All rights reserved.
+ *
+ * This source code is licensed under the MIT-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Based on Asim Malik android source code, copyright (c) 2015
+ *
+ **/
+
+package com.reactnative.googlefit;
+
+import com.rfs.GoogleFitManager;
+
+import com.facebook.react.bridge.ReactContext;
+import android.util.Log;
+
+import com.google.android.gms.fitness.Fitness;
+import com.google.android.gms.fitness.FitnessStatusCodes;
+import com.google.android.gms.common.api.Status;
+import com.google.android.gms.common.api.ResultCallback;
+import com.google.android.gms.fitness.data.DataType;
+import com.facebook.react.bridge.ReadableArray;
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.WritableArray;
+import com.facebook.react.bridge.WritableMap;
+
+import com.google.android.gms.fitness.result.ListSubscriptionsResult;
+import com.google.android.gms.fitness.data.Subscription;
+
+import com.facebook.react.modules.core.DeviceEventManagerModule;
+import android.support.annotation.Nullable;
+
+
+public class RecordingApi {
+
+    private ReactContext reactContext;
+    private GoogleFitManager googleFitManager;
+
+    private static final String TAG = "RecordingApi";
+
+    public FitnessRecord (ReactContext reactContext, GoogleFitManager googleFitManager) {
+
+        this.reactContext = reactContext;
+        this.googleFitManager = googleFitManager;
+
+    }
+
+    // This function could take an array as parameters and subscribe to each fitness data type provided
+    public ReadableArray subscribe () {
+
+        final WritableArray result = Arguments.createArray();
+
+        Fitness.RecordingApi.subscribe(googleFitManager.getGoogleApiClient(), DataType.TYPE_STEP_COUNT_CUMULATIVE)
+            .setResultCallback(new ResultCallback <Status> () {
+
+                @Override
+                public void onResult(Status status) {
+                    if (status.isSuccess()) {
+                            if (status.getStatusCode()
+                                    == FitnessStatusCodes.SUCCESS_ALREADY_SUBSCRIBED) {
+                                Log.i(TAG, "Existing subscription for activity detected.");
+                                sendEvent(reactContext, "RecordingSuccess", null);
+                            } else {
+                                Log.i(TAG, "Successfully subscribed!");
+                                sendEvent(reactContext, "RecordingSuccess", null);
+                            }
+                        } else {
+                            Log.i(TAG, "There was a problem subscribing.");
+                            sendEvent(reactContext, "RecordingError", null);
+                        }
+                }
+            });
+        Fitness.RecordingApi.subscribe(googleFitManager.getGoogleApiClient(), DataType.TYPE_DISTANCE_DELTA)
+            .setResultCallback(new ResultCallback <Status> () {
+
+                @Override
+                public void onResult(Status status) {
+
+                    if (status.isSuccess()) {
+                            if (status.getStatusCode()
+                                    == FitnessStatusCodes.SUCCESS_ALREADY_SUBSCRIBED) {
+                                Log.i(TAG, "Existing subscription for activity detected.");
+                                sendEvent(reactContext, "DistanceRecordingSuccess", null);
+                            } else {
+                                Log.i(TAG, "Successfully subscribed!");
+                                sendEvent(reactContext, "DistanceRecordingSuccess", null);
+                            }
+                        } else {
+                            Log.i(TAG, "There was a problem subscribing.");
+                            sendEvent(reactContext, "DistanceRecordFail", null);
+                        }
+                }
+            });
+
+        // Could be a void function instead of returning this string - success/error messages 
+        // are emitted as events 
+        result.pushString("Success :)");
+        return result;
+    }
+
+    private void sendEvent(ReactContext reactContext,
+        String eventName, @Nullable WritableMap params) {
+        reactContext
+            .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+            .emit(eventName, params);
+    }
+}

--- a/index.android.js
+++ b/index.android.js
@@ -17,7 +17,12 @@ class RNGoogleFit {
             res => callback(false, res)
     );
     }
-
+    /**
+     * Start recording fitness data (steps, distance)
+     * This function relies on sending events to signal the RecordingAPI status
+     * Simply create an event listener for the {DATA_TYPE}_RECORDING (ex. STEP_RECORDING)
+     * and check for {recording: true} as the event data
+     */
     startRecording() {
         googleFit.startFitnessRecording();
     }
@@ -95,8 +100,8 @@ class RNGoogleFit {
      */
 
     getDailyDistanceSamples(options, callback) {
-        let startDate = Date.parse(options.startDate);
-        let endDate = Date.parse(options.endDate);
+        let startDate = options.startDate != undefined ? Date.parse(options.startDate) : (new Date()).setHours(0,0,0,0);
+        let endDate = options.endDate != undefined ? Date.parse(options.endDate) : (new Date()).valueOf();
         googleFit.getDailyDistanceSamples( startDate,
             endDate,
             (msg) => {

--- a/index.android.js
+++ b/index.android.js
@@ -18,6 +18,10 @@ class RNGoogleFit {
     );
     }
 
+    startRecording() {
+        googleFit.startFitnessRecording();
+    }
+
     //Will be deprecated in future releases
     getSteps(dayStart,dayEnd) {
         googleFit.getDailySteps(Date.parse(dayStart), Date.parse(dayEnd));


### PR DESCRIPTION
Record steps and distance without the need for third-party apps.  Simply call ```GoogleFit.startRecording()```  after authorizing.

The function need only be called once but can be called multiple times (Perhaps every time the app is opened).  Once called, the Recording API is initialized for selected fitness data types and will be reinitialized when the mobile device reboots. 