### PR TITLE
GoogleFitManager: promisify authorize method

### DIFF
--- a/android/src/main/java/com/reactnative/googlefit/GoogleFitManager.java
+++ b/android/src/main/java/com/reactnative/googlefit/GoogleFitManager.java
@@ -25,6 +25,7 @@ import com.facebook.react.bridge.Callback;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.bridge.Promise;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GoogleApiAvailability;
@@ -107,7 +108,7 @@ public class GoogleFitManager implements
 
     public CalorieHistory getCalorieHistory() { return calorieHistory; }
 
-    public void authorize() {
+    public void authorize(final Promise promise) {
         final ReactContext mReactContext = this.mReactContext;
 
         mApiClient = new GoogleApiClient.Builder(mReactContext.getApplicationContext())
@@ -122,12 +123,15 @@ public class GoogleFitManager implements
                         @Override
                         public void onConnected(@Nullable Bundle bundle) {
                             Log.i(TAG, "Authorization - Connected");
+                            promise.resolve(null);
                             sendEvent(mReactContext, "GoogleFitAuthorizeSuccess", null);
                         }
 
                         @Override
                         public void onConnectionSuspended(int i) {
-                            Log.i(TAG, "Authorization - Connection Suspended");
+                            String message = "Authorization - Connection Suspended";
+                            Log.i(TAG, message);
+                            promise.reject("GoogleFitAuthorizeFailure", message);
                             if ((mApiClient != null) && (mApiClient.isConnected())) {
                                 mApiClient.disconnect();
                             }
@@ -141,7 +145,7 @@ public class GoogleFitManager implements
                             WritableMap map = Arguments.createMap();
                             map.putString("message", "" + connectionResult);
                             sendEvent(mReactContext, "GoogleFitAuthorizeFailure", map);
-
+                            promise.reject("GoogleFitAuthorizeFailure", connectionResult.toString());
                             Log.i(TAG, "Authorization - Failed Authorization Mgr:" + connectionResult);
                             if (mAuthInProgress) {
                                 Log.i(TAG, "Authorization - Already attempting to resolve an error.");

--- a/android/src/main/java/com/reactnative/googlefit/GoogleFitModule.java
+++ b/android/src/main/java/com/reactnative/googlefit/GoogleFitModule.java
@@ -23,6 +23,7 @@ import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.LifecycleEventListener;
+import com.facebook.react.bridge.Promise;
 import com.facebook.react.uimanager.IllegalViewOperationException;
 
 
@@ -68,7 +69,7 @@ LifecycleEventListener {
     }
     
     @ReactMethod
-    public void authorize() {
+    public void authorize(final Promise promise) {
         final Activity activity = getCurrentActivity();
         
         if (mGoogleFitManager == null) {
@@ -76,9 +77,10 @@ LifecycleEventListener {
         }
         
         if (mGoogleFitManager.isAuthorized()) {
+            promise.resolve(null);
             return;
         }
-        mGoogleFitManager.authorize();
+        mGoogleFitManager.authorize(promise);
     }
     
     @ReactMethod

--- a/index.android.js
+++ b/index.android.js
@@ -11,7 +11,7 @@ class RNGoogleFit {
     eventListeners = []
 
     authorize () {
-        googleFit.authorize();
+        return googleFit.authorize();
     }
 
     removeListeners = () => {


### PR DESCRIPTION
Instead of this:

```
GoogleFit.onAuthorize(() => {
  dispatch('AUTH SUCCESS');
});

GoogleFit.onAuthorizeFailure(() => {
  dispatch('AUTH ERROR');
});

GoogleFit.authorize();
```

I find it's easier to do this:
```
GoogleFit.authorize()
  .then(() =>
    resolve(
      dispatch({
        type: TOGGLE_GOOGLE_FIT,
        shouldUseGoogleFit: true,
      }),
    ),
  )
  .catch(() => reject(new Error('Failed to enable Google Fit')));
```

This PR doesn't change the existing API, with one exception: `GoogleFit.authorize()` now returns a Promise.