### PR TITLE
RN v56+ changes

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,13 +11,17 @@ buildscript {
 
 apply plugin: 'com.android.library'
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion safeExtGet('compileSdkVersion', 23)
+    buildToolsVersion safeExtGet('buildToolsVersion', '23.0.1')
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 23
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 23)
         versionCode 1
         versionName "1.0"
         ndk {


### PR DESCRIPTION
To make this work on React Native v0.56.0 and later projects, the Android API version needs to be updated to at least 25. The `safeExtGet` function implemented will get the config from React Native project's main `build.gradle` file to use the project version else if `ext` is not available, it will use API 23. This won't affect the projects currently using this package with API 23.