### PR TITLE
Ability to pass custom Scopes

### DIFF
--- a/android/src/main/java/com/reactnative/googlefit/GoogleFitManager.java
+++ b/android/src/main/java/com/reactnative/googlefit/GoogleFitManager.java
@@ -19,6 +19,7 @@ import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.Log;
+import java.util.ArrayList;
 
 import com.facebook.react.bridge.ActivityEventListener;
 import com.facebook.react.bridge.Arguments;
@@ -116,17 +117,19 @@ public class GoogleFitManager implements
 
     public CalorieHistory getCalorieHistory() { return calorieHistory; }
 
-    public void authorize() {
+    public void authorize(ArrayList<String> userScopes) {
         final ReactContext mReactContext = this.mReactContext;
 
-        mApiClient = new GoogleApiClient.Builder(mReactContext.getApplicationContext())
+        GoogleApiClient.Builder apiClientBuilder = new GoogleApiClient.Builder(mReactContext.getApplicationContext())
                 .addApi(Fitness.SENSORS_API)
                 .addApi(Fitness.HISTORY_API)
-                .addApi(Fitness.RECORDING_API)
-                .addScope(new Scope(Scopes.FITNESS_ACTIVITY_READ))
-                .addScope(new Scope(Scopes.FITNESS_BODY_READ_WRITE))
-                .addScope(new Scope(Scopes.FITNESS_LOCATION_READ))
-                .addScope(new Scope("https://www.googleapis.com/auth/fitness.blood_pressure.read"))
+                .addApi(Fitness.RECORDING_API);
+
+        for (String scopeName : userScopes) {
+            apiClientBuilder.addScope(new Scope(scopeName));
+        }
+
+        mApiClient = apiClientBuilder
                 .addConnectionCallbacks(
                     new GoogleApiClient.ConnectionCallbacks() {
                         @Override

--- a/android/src/main/java/com/reactnative/googlefit/GoogleFitModule.java
+++ b/android/src/main/java/com/reactnative/googlefit/GoogleFitModule.java
@@ -13,6 +13,7 @@ package com.reactnative.googlefit;
 import android.app.Activity;
 import android.content.pm.PackageManager;
 import android.util.Log;
+import java.util.ArrayList;
 import android.content.Intent;
 
 import com.facebook.react.bridge.Arguments;
@@ -74,7 +75,7 @@ public class GoogleFitModule extends ReactContextBaseJavaModule implements Lifec
     }
 
     @ReactMethod
-    public void authorize() {
+    public void authorize(ReadableMap options) {
         final Activity activity = getCurrentActivity();
 
         if (mGoogleFitManager == null) {
@@ -84,7 +85,15 @@ public class GoogleFitModule extends ReactContextBaseJavaModule implements Lifec
         if (mGoogleFitManager.isAuthorized()) {
             return;
         }
-        mGoogleFitManager.authorize();
+
+        ReadableArray scopes = options.getArray("scopes");
+        ArrayList<String> scopesList = new ArrayList<String>();
+
+        for (Object type : scopes.toArrayList()) {
+            scopesList.add(type.toString());
+        }
+
+        mGoogleFitManager.authorize(scopesList);
     }
 
     @ReactMethod

--- a/src/scopes.js
+++ b/src/scopes.js
@@ -1,0 +1,38 @@
+const fitnessScopes = {
+  FITNESS_ACTIVITY_READ:
+    'https://www.googleapis.com/auth/fitness.activity.read',
+  FITNESS_ACTIVITY_READ_WRITE:
+    'https://www.googleapis.com/auth/fitness.activity.write',
+  FITNESS_LOCATION_READ:
+    'https://www.googleapis.com/auth/fitness.location.read',
+  FITNESS_LOCATION_READ_WRITE:
+    'https://www.googleapis.com/auth/fitness.location.write',
+  FITNESS_BODY_READ: 'https://www.googleapis.com/auth/fitness.body.read',
+  FITNESS_BODY_READ_WRITE: 'https://www.googleapis.com/auth/fitness.body.write',
+  FITNESS_NUTRITION_READ:
+    'https://www.googleapis.com/auth/fitness.nutrition.read',
+  FITNESS_NUTRITION_READ_WRITE:
+    'https://www.googleapis.com/auth/fitness.nutrition.write',
+  FITNESS_BLOOD_PRESSURE_READ:
+    'https://www.googleapis.com/auth/fitness.blood_pressure.read',
+  FITNESS_BLOOD_PRESSURE_READ_WRITE:
+    'https://www.googleapis.com/auth/fitness.blood_pressure.write',
+  FITNESS_BLOOD_GLUCOSE_READ:
+    'https://www.googleapis.com/auth/fitness.blood_glucose.read',
+  FITNESS_BLOOD_GLUCOSE_READ_WRITE:
+    'https://www.googleapis.com/auth/fitness.blood_glucose.write',
+  FITNESS_OXYGEN_SATURATION_READ:
+    'https://www.googleapis.com/auth/fitness.oxygen_saturation.read',
+  FITNESS_OXYGEN_SATURATION_READ_WRITE:
+    'https://www.googleapis.com/auth/fitness.oxygen_saturation.write',
+  FITNESS_BODY_TEMPERATURE_READ:
+    'https://www.googleapis.com/auth/fitness.body_temperature.read',
+  FITNESS_BODY_TEMPERATURE_READ_WRITE:
+    'https://www.googleapis.com/auth/fitness.body_temperature.write',
+  FITNESS_REPRODUCTIVE_HEALTH_READ:
+    'https://www.googleapis.com/auth/fitness.reproductive_health.read',
+  FITNESS_REPRODUCTIVE_HEALTH_READ_WRITE:
+    'https://www.googleapis.com/auth/fitness.reproductive_health.write'
+};
+
+export default fitnessScopes;


### PR DESCRIPTION
Currently, the requested scopes are hardcoded and can't be configured or changed, this leads to UX issued (it could be suspicious when the application requests permission to access the blood pressure data if it is not needed).

So, this PR adds an ability to configure scopes through adding `options` params to the `authorize` method, and the function can be called as:
```
GoogleFit.authorize({
  scopes: [
    Scopes.FITNESS_ACTIVITY_READ_WRITE,
    Scopes.FITNESS_BODY_READ_WRITE,
  ],
});
```

It has compatibility with the previous version because if scopes are not provided it uses the same scope as the current version of this lib.

Also, I've added `Scopes` export with all the available scopes.

@StasDoskalenko please, let me know what you think. I'll add documentation if the PR is ok.

Also, I think this library need some kind of a style guide and linting (maybe Prettier at least). 