### PR TITLE
use auth and fitness versions from root projects if available

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,6 +35,6 @@ android {
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation 'com.facebook.react:react-native:+'
-    implementation 'com.google.android.gms:play-services-auth:+'
-    implementation 'com.google.android.gms:play-services-fitness:+'
+    implementation "com.google.android.gms:play-services-auth:${safeExtGet('authVersion', '+')}"
+    implementation "com.google.android.gms:play-services-fitness:${safeExtGet('fitnessVersion', '+')}"
 }


### PR DESCRIPTION
With the latest update to google play services, `androidx` has been used as default instead of `support library`. Due to this, the older apps are failing to build because the latest play services require the apps to use `androidx`. `androidx` and `support library` do not work together. So, this PR provides applications to specify play services auth and fitness versions.

https://developers.google.com/android/guides/releases#june_17_2019