### PR TITLE
Expose isAuthorized boolean in TypeScript

### DIFF
--- a/index.android.d.ts
+++ b/index.android.d.ts
@@ -2,6 +2,7 @@
 declare module 'react-native-google-fit' {
   export interface GoogleFit {
     eventListeners: any[]
+    isAuthorized: boolean
 
     authorize(options?: AuthorizeOptions): Promise<any> | void
 

--- a/index.android.d.ts
+++ b/index.android.d.ts
@@ -6,6 +6,8 @@ declare module 'react-native-google-fit' {
 
     authorize(options?: AuthorizeOptions): Promise<any> | void
 
+    checkIsAuthorized: () => Promise<void>
+
     disconnect(): void
 
     removeListeners: () => void


### PR DESCRIPTION
The JavaScript API provides a boolean called `isAuthorized` that is `true` when the user has authorized Google Fit on their device. Unfortunately, this boolean is not exposed in the TypeScript API. This PR amends that.