### PR TITLE
Fix heart rate read limit

### DIFF
--- a/android/src/main/java/com/reactnative/googlefit/HeartrateHistory.java
+++ b/android/src/main/java/com/reactnative/googlefit/HeartrateHistory.java
@@ -46,7 +46,7 @@ public class HeartrateHistory {
     private DataSet Dataset;
     private DataType dataType;
 
-    private static final String TAG = "Weights History";
+    private static final String TAG = "Heart Rate History";
 
     public HeartrateHistory(ReactContext reactContext, GoogleFitManager googleFitManager, DataType dataType){
         this.mReactContext = reactContext;
@@ -55,7 +55,7 @@ public class HeartrateHistory {
     }
 
     public HeartrateHistory(ReactContext reactContext, GoogleFitManager googleFitManager){
-        this(reactContext, googleFitManager, DataType.TYPE_WEIGHT);
+        this(reactContext, googleFitManager, DataType.TYPE_HEART_RATE_BPM);
     }
 
     public void setDataType(DataType dataType) {
@@ -64,15 +64,12 @@ public class HeartrateHistory {
 
     public ReadableArray getHistory(long startTime, long endTime) {
         DateFormat dateFormat = DateFormat.getDateInstance();
-        // for height we need to take time, since GoogleFit foundation - https://stackoverflow.com/questions/28482176/read-the-height-in-googlefit-in-android
 
         DataReadRequest.Builder readRequestBuilder = new DataReadRequest.Builder()
                 .read(this.dataType)
                 .setTimeRange(startTime, endTime, TimeUnit.MILLISECONDS);
         if (this.dataType == HealthDataTypes.TYPE_BLOOD_PRESSURE) {
             readRequestBuilder.bucketByTime(1, TimeUnit.DAYS);
-        } else {
-            readRequestBuilder.setLimit(5); // need only one height, since it's unchangable
         }
 
         DataReadRequest readRequest = readRequestBuilder.build();
@@ -100,10 +97,12 @@ public class HeartrateHistory {
     }
 
     public boolean save(ReadableMap sample) {
+        // TODO: how to save blood pressure?
+
         this.Dataset = createDataForRequest(
-                this.dataType,    // for height, it would be DataType.TYPE_HEIGHT
+                this.dataType,    // for heart rate, it would be DataType.TYPE_HEART_RATE_BPM
                 DataSource.TYPE_RAW,
-                sample.getDouble("value"),                  // weight in kgs, height in metrs
+                sample.getDouble("value"),                  // heart rate in bmp
                 (long)sample.getDouble("date"),              // start time
                 (long)sample.getDouble("date"),                // end time
                 TimeUnit.MILLISECONDS                // Time Unit, for example, TimeUnit.MILLISECONDS


### PR DESCRIPTION
Currently this library is unable to read more than 5 heart rate records at a time using `getHeartRateSamples`. I believe this is because the original code for `HeartrateHistory` was based on `BodyHistory` but accidentally carried over some unnecessary code. I have removed the 5 record limit and updated some of the comments in `HeartrateHistory` to be more accurate.

Fixes #121 