### PR TITLE
Fix and modify recording api for step, typescript and allow to ask permission for distance

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,7 +452,7 @@ A React Native bridge module for interacting with Google Fit
 
 * code refactoring
 * optimization
-This is forked from React-native-google-fit.
+
 Copyright (c) 2017-present, Stanislav Doskalenko
 doskalenko.s@gmail.com
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,4 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.reactnative.googlefit">
+          <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
 </manifest>

--- a/android/src/main/java/com/reactnative/googlefit/RecordingApi.java
+++ b/android/src/main/java/com/reactnative/googlefit/RecordingApi.java
@@ -49,7 +49,7 @@ public class RecordingApi {
     public static DataType getDataType(String dataTypeName) {
         switch (dataTypeName) {
             case "step":
-                return DataType.TYPE_STEP_COUNT_CUMULATIVE;
+                return DataType.TYPE_STEP_COUNT_DELTA;
             case "distance":
                 return DataType.TYPE_DISTANCE_DELTA;
             case "activity":

--- a/index.android.d.ts
+++ b/index.android.d.ts
@@ -18,7 +18,7 @@ declare module 'react-native-google-fit' {
      * Simply create an event listener for the {DATA_TYPE}_RECORDING (ex. STEP_RECORDING)
      * and check for {recording: true} as the event data
      */
-    startRecording: (callback: (param: any) => void) => void
+    startRecording: (callback: (param: any) => void, dataTypes: Array<string>) => void
 
     getSteps(dayStart: Date | string, dayEnd: Date | string): any
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -5,7 +5,7 @@ export function buildDailySteps(steps) {
       continue
     }
 
-    const dateFormatted = getFormattedDate(new Date(step.startDate))
+    const dateFormatted = getFormattedDate(new Date(step.endDate))
 
     if (!(dateFormatted in results)) {
       results[dateFormatted] = 0


### PR DESCRIPTION
A better approach for #142,  instead of simply removing the distance to avoid any sensitive permissions ask for android 6.0+ (that can cause a crash).
Allow to pass argument as following,

        GoogleFit.startRecording( callback => {
          console.log(callback);
           // Process data from Google Fit Recording API (no google fit app needed)
         }, ['step','distance']);

Permission panel will be promoted, if permission is denied, remove `distance` from record list to ensure others still get subscribed. 
Note: Permission panel will always pop out on run time if `GoogleFit.startRecording ` with `distance` argument is called on your code, until user select `"never ask again"`.

Step recording now matches the correct DataType as Google Fit App for general use and `readMe` doc, but it may break if someone do use the old DateType for other purposes.

The most critical part is once `GoogleFit.startRecording()` is called,
`GoogleFit.getDailyStepCountSamples(options)` can always fetch data without installing `Google Fit` on your device! (I tested on emulator that cannot install Google fit and my phone after disabling the Google fit). **But require more testing**

I do realize that if we are able to handle all `dataTypes` correctly through recording api, ask any permissions if necessary, and upgrade the deprecated API, the repo can run entire by itself wihtout installing Google Fit.





