### PR TITLE
Add Sleep Data support

### DIFF
--- a/android/src/main/java/com/reactnative/googlefit/GoogleFitManager.java
+++ b/android/src/main/java/com/reactnative/googlefit/GoogleFitManager.java
@@ -60,6 +60,7 @@ public class GoogleFitManager implements
     private RecordingApi recordingApi;
     private ActivityHistory activityHistory;
     private HydrationHistory hydrationHistory;
+    private SleepHistory sleepHistory;
 
     private static final String TAG = "RNGoogleFit";
 
@@ -81,6 +82,7 @@ public class GoogleFitManager implements
         this.recordingApi = new RecordingApi(mReactContext, this);
         this.activityHistory = new ActivityHistory(mReactContext, this);
         this.hydrationHistory = new HydrationHistory(mReactContext, this);
+        this.sleepHistory = new SleepHistory(mReactContext, this);
         //        this.stepSensor = new StepSensor(mReactContext, activity);
     }
 
@@ -124,6 +126,8 @@ public class GoogleFitManager implements
     public NutritionHistory getNutritionHistory() { return nutritionHistory; }
 
     public HydrationHistory getHydrationHistory() { return hydrationHistory; }
+
+    public SleepHistory getSleepHistory() { return sleepHistory; }
 
     public void authorize(ArrayList<String> userScopes) {
         final ReactContext mReactContext = this.mReactContext;

--- a/android/src/main/java/com/reactnative/googlefit/GoogleFitModule.java
+++ b/android/src/main/java/com/reactnative/googlefit/GoogleFitModule.java
@@ -416,4 +416,13 @@ public class GoogleFitModule extends ReactContextBaseJavaModule implements Lifec
             errorCallback.invoke(e.getMessage());
         }
     }
+
+    @ReactMethod
+    public void getSleepData(double startDate, double endDate, Callback errorCallback, Callback successCallback) {
+        try {
+           mGoogleFitManager.getSleepHistory().getSleepData((long)startDate, (long)endDate, errorCallback, successCallback);
+        } catch (Error e) {
+            errorCallback.invoke(e.getMessage());
+        }
+    }
 }

--- a/android/src/main/java/com/reactnative/googlefit/SleepHistory.java
+++ b/android/src/main/java/com/reactnative/googlefit/SleepHistory.java
@@ -25,8 +25,11 @@ import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.google.android.gms.auth.api.signin.GoogleSignIn;
+import com.google.android.gms.auth.api.signin.GoogleSignInAccount;
+import com.google.android.gms.common.Scopes;
 import com.google.android.gms.common.api.PendingResult;
 import com.google.android.gms.common.api.ResultCallback;
+import com.google.android.gms.common.api.Scope;
 import com.google.android.gms.fitness.Fitness;
 import com.google.android.gms.fitness.FitnessActivities;
 import com.google.android.gms.fitness.data.Bucket;
@@ -66,7 +69,7 @@ public class SleepHistory {
     private ReactContext mReactContext;
     private GoogleFitManager googleFitManager;
 
-    private static final String TAG = "RNGoogleFit";
+    private static final String TAG = "RNGoogleFit-Sleep";
 
     public SleepHistory(ReactContext reactContext, GoogleFitManager googleFitManager){
         this.mReactContext = reactContext;
@@ -81,7 +84,8 @@ public class SleepHistory {
                 .setTimeInterval((long) startDate, (long) endDate, TimeUnit.MILLISECONDS)
                 .build();
 
-        Fitness.getSessionsClient(this.mReactContext, GoogleSignIn.getLastSignedInAccount(this.mReactContext))
+        GoogleSignInAccount gsa = GoogleSignIn.getAccountForScopes(this.mReactContext, new Scope(Scopes.FITNESS_ACTIVITY_READ));
+        Fitness.getSessionsClient(this.mReactContext, gsa)
                 .readSession(request)
                 .addOnSuccessListener(new OnSuccessListener<SessionReadResponse>() {
                     @Override
@@ -91,6 +95,7 @@ public class SleepHistory {
                             .filter(new Predicate<Session>() {
                                 @Override
                                 public boolean test(Session s) {
+                                    Log.i(TAG, "Activity found: " + s.getActivity());
                                     return s.getActivity().equals(FitnessActivities.SLEEP);
                                 }
                             })

--- a/android/src/main/java/com/reactnative/googlefit/SleepHistory.java
+++ b/android/src/main/java/com/reactnative/googlefit/SleepHistory.java
@@ -11,9 +11,12 @@
 
 package com.reactnative.googlefit;
 
+import android.os.Build;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.Log;
+
+import androidx.annotation.RequiresApi;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Callback;
@@ -25,17 +28,24 @@ import com.google.android.gms.auth.api.signin.GoogleSignIn;
 import com.google.android.gms.common.api.PendingResult;
 import com.google.android.gms.common.api.ResultCallback;
 import com.google.android.gms.fitness.Fitness;
+import com.google.android.gms.fitness.FitnessActivities;
 import com.google.android.gms.fitness.data.Bucket;
 import com.google.android.gms.fitness.data.DataPoint;
 import com.google.android.gms.fitness.data.DataSet;
 import com.google.android.gms.fitness.data.DataType;
 import com.google.android.gms.fitness.data.Field;
 import com.google.android.gms.fitness.data.DataSource;
+import com.google.android.gms.fitness.data.Session;
 import com.google.android.gms.fitness.request.DataSourcesRequest;
 import com.google.android.gms.fitness.request.DataReadRequest;
+import com.google.android.gms.fitness.request.SessionReadRequest;
 import com.google.android.gms.fitness.result.DataReadResult;
 import com.google.android.gms.fitness.result.DataSourcesResult;
+import com.google.android.gms.fitness.result.SessionReadResponse;
 import com.google.android.gms.fitness.data.Device;
+import com.google.android.gms.tasks.OnCompleteListener;
+import com.google.android.gms.tasks.OnFailureListener;
+import com.google.android.gms.tasks.OnSuccessListener;
 
 import java.text.DateFormat;
 import java.text.Format;
@@ -47,6 +57,9 @@ import java.text.SimpleDateFormat;
 import java.util.TimeZone;
 import java.util.ArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
 
 public class SleepHistory {
 
@@ -73,7 +86,7 @@ public class SleepHistory {
                 .addOnSuccessListener(new OnSuccessListener<SessionReadResponse>() {
                     @Override
                     public void onSuccess(SessionReadResponse response) {
-                        List<Session> sleepSessions = response.getSessions()
+                        List<Object> sleepSessions = response.getSessions()
                             .stream()
                             .filter(new Predicate<Session>() {
                                 @Override
@@ -85,11 +98,11 @@ public class SleepHistory {
 
                         WritableArray sleep = Arguments.createArray();
 
-                        for (Session session : sleepSessions) {
-                            List<DataSet> dataSets = response.getDataSet(session);
+                        for (Object session : sleepSessions) {
+                            List<DataSet> dataSets = response.getDataSet((Session) session);
 
                             for (DataSet dataSet : dataSets) {
-                                processDataSet(dataSet, session, sleep);
+                                processDataSet(dataSet, (Session) session, sleep);
                             }
                         }
 

--- a/android/src/main/java/com/reactnative/googlefit/SleepHistory.java
+++ b/android/src/main/java/com/reactnative/googlefit/SleepHistory.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) 2017-present, Stanislav Doskalenko - doskalenko.s@gmail.com
+ * All rights reserved.
+ *
+ * This source code is licensed under the MIT-style license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * Based on Asim Malik android source code, copyright (c) 2015
+ *
+ **/
+
+package com.reactnative.googlefit;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.util.Log;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.Callback;
+import com.facebook.react.bridge.ReactContext;
+import com.facebook.react.bridge.WritableArray;
+import com.facebook.react.bridge.WritableMap;
+import com.facebook.react.modules.core.DeviceEventManagerModule;
+import com.google.android.gms.auth.api.signin.GoogleSignIn;
+import com.google.android.gms.common.api.PendingResult;
+import com.google.android.gms.common.api.ResultCallback;
+import com.google.android.gms.fitness.Fitness;
+import com.google.android.gms.fitness.data.Bucket;
+import com.google.android.gms.fitness.data.DataPoint;
+import com.google.android.gms.fitness.data.DataSet;
+import com.google.android.gms.fitness.data.DataType;
+import com.google.android.gms.fitness.data.Field;
+import com.google.android.gms.fitness.data.DataSource;
+import com.google.android.gms.fitness.request.DataSourcesRequest;
+import com.google.android.gms.fitness.request.DataReadRequest;
+import com.google.android.gms.fitness.result.DataReadResult;
+import com.google.android.gms.fitness.result.DataSourcesResult;
+import com.google.android.gms.fitness.data.Device;
+
+import java.text.DateFormat;
+import java.text.Format;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.text.SimpleDateFormat;
+import java.util.TimeZone;
+import java.util.ArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class SleepHistory {
+
+    private ReactContext mReactContext;
+    private GoogleFitManager googleFitManager;
+
+    private static final String TAG = "RNGoogleFit";
+
+    public SleepHistory(ReactContext reactContext, GoogleFitManager googleFitManager){
+        this.mReactContext = reactContext;
+        this.googleFitManager = googleFitManager;
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.N)
+    public void getSleepData(double startDate, double endDate, final Callback errorCallback, final Callback successCallback) {
+        SessionReadRequest request = new SessionReadRequest.Builder()
+                .readSessionsFromAllApps()
+                .read(DataType.TYPE_ACTIVITY_SEGMENT)
+                .setTimeInterval((long) startDate, (long) endDate, TimeUnit.MILLISECONDS)
+                .build();
+
+        Fitness.getSessionsClient(this.mReactContext, GoogleSignIn.getLastSignedInAccount(this.mReactContext))
+                .readSession(request)
+                .addOnSuccessListener(new OnSuccessListener<SessionReadResponse>() {
+                    @Override
+                    public void onSuccess(SessionReadResponse response) {
+                        List<Session> sleepSessions = response.getSessions()
+                            .stream()
+                            .filter(new Predicate<Session>() {
+                                @Override
+                                public boolean test(Session s) {
+                                    return s.getActivity().equals(FitnessActivities.SLEEP);
+                                }
+                            })
+                            .collect(Collectors.toList());
+
+                        WritableArray sleep = Arguments.createArray();
+
+                        for (Session session : sleepSessions) {
+                            List<DataSet> dataSets = response.getDataSet(session);
+
+                            for (DataSet dataSet : dataSets) {
+                                processDataSet(dataSet, session, sleep);
+                            }
+                        }
+
+                        successCallback.invoke(sleep);
+                    }
+                })
+                .addOnFailureListener(new OnFailureListener() {
+                    @Override
+                    public void onFailure(@NonNull Exception e) {
+                        errorCallback.invoke(e.getMessage());
+                    }
+                });
+    }
+
+    private void processDataSet(DataSet dataSet, Session session, WritableArray map) {
+        DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+        dateFormat.setTimeZone(TimeZone.getDefault());
+
+        WritableMap sleepMap = Arguments.createMap();
+
+        for (DataPoint dp : dataSet.getDataPoints()) {
+            sleepMap.putString("value", dp.getValue(Field.FIELD_ACTIVITY).asActivity());
+            sleepMap.putString("startDate", dateFormat.format(dp.getStartTime(TimeUnit.MILLISECONDS)));
+            sleepMap.putString("endDate", dateFormat.format(dp.getEndTime(TimeUnit.MILLISECONDS)));
+            map.pushMap(sleepMap);
+        }
+    }
+
+}

--- a/index.android.d.ts
+++ b/index.android.d.ts
@@ -151,6 +151,18 @@ declare module 'react-native-google-fit' {
       callback: (isError: boolean, result: any) => void
     ) => void
 
+    /**
+     * Get the sleep sessions over a specified date range.
+     * @param {Object} options getSleepData accepts an options object containing required startDate: ISO8601Timestamp and endDate: ISO8601Timestamp.
+     * @param {Function} callback The function will be called with an array of elements.
+     */
+    getSleepData: (
+      options: any,
+      callback?: (isError: boolean, result: any) => void
+    ) => Promise<any> | void
+
+
+
     isAvailable(callback: (isError: boolean, result: boolean) => void): void
 
     isEnabled(callback: (isError: boolean, result: boolean) => void): void

--- a/index.android.js
+++ b/index.android.js
@@ -543,6 +543,35 @@ class RNGoogleFit {
       }
     )
   }
+
+  /**
+   * Get the sleep sessions over a specified date range.
+   * @param {Object} options getSleepData accepts an options object containing required startDate: ISO8601Timestamp and endDate: ISO8601Timestamp.
+   * @param {Function} callback The function will be called with an array of elements.
+   */
+
+  getSleepData = (options, callback) => {
+    const startDate = !isNil(options.startDate)
+      ? Date.parse(options.startDate)
+      : new Date().setHours(0, 0, 0, 0)
+    const endDate = !isNil(options.endDate)
+      ? Date.parse(options.endDate)
+      : new Date().valueOf()
+    
+    googleFit.getSleepData(
+      startDate,
+      endDate,
+      msg => callback(true, msg),
+      res => {
+        if (res.length > 0) {
+          callback(false, prepareResponse(res, 'value'))
+        } else {
+          callback('There is no sleep data for this period.', false)
+        }
+      }
+    )
+  }
+
 }
 
 export default new RNGoogleFit()

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "eslint-plugin-react": "7.12.4",
     "eslint-plugin-standard": "4.0.0",
     "eslint-config-standard-react": "7.0.2",
+    "moment": "2.20.1",
     "react-native": "0.58.6"
   }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,5 @@
+import moment from 'moment';
+
 export function buildDailySteps(steps) {
   const results = {}
   for (const step of steps) {
@@ -36,8 +38,13 @@ export function prepareResponse(response, byKey = 'value') {
   return response
     .map(el => {
       if (!isNil(el[byKey])) {
-        el.startDate = new Date(el.startDate).toISOString()
-        el.endDate = new Date(el.endDate).toISOString()
+        // Android is returning a date format from Fit that new Date() can't parse, e.g.: 2020-05-21T06:06:05.871-0400
+        // Note the time offset at the end rather is non-standard compared to ISO which new Date expects. This works in
+        // the Chrome V8 debugger, but not on device. Using momentJS here to get around this issue.
+        // el.startDate = new Date(el.startDate).toISOString()
+        // el.endDate = new Date(el.endDate).toISOString()
+        el.startDate = moment(el.startDate).toISOString()
+        el.endDate = moment(el.endDate).toISOString()
         return el
       }
     })


### PR DESCRIPTION
This PR adds support for Google Fit Sleep data. I ended up adding a dev dependency for MomentJS because Android was crashing on invalid dates coming back from the sleep data samples. Using moment instead of "new Date()" to parse those incoming dates fixes the crash.