### PR TITLE
Feat. Update, remove and updated deprecated step Api.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,14 @@ A React Native bridge module for interacting with Google Fit
          console.log('Daily steps >>> ', res)
      })
      .catch((err) => {console.warn(err)})
+    
+    // shortcut functions, 
+    // return weekly or daily steps of given date
+    // all params are optional, using new Date() without given date, 
+    // adjustment is 0 by default, determine the first day of week, 0 == Sunday, 1==Monday, etc.
+    GoogleFit.getDailySteps(date).then.catch()
+    GoogleFit.getWeeklySteps(date, adjustment).then().catch()
+     
     ```
 
     **Response:**

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ A React Native bridge module for interacting with Google Fit
     ];
     ```
     Step also support a optional config to get rawStep Data for detail usage.
-    ```
+    ```javascript
     const dailyOptions = {
         startDate: "2020-07-06T00:00:00.000Z",
         endDate:  "2020-07-06T23:59:00.000Z",
@@ -124,7 +124,7 @@ A React Native bridge module for interacting with Google Fit
     }
    ```
    **Response:**
-   ```
+   ```javascript
    // {bucketTime: 15, bucketUnit: 'MINUTE'}
    [
       { source: "com.google.android.gms:estimated_steps", 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,48 @@ A React Native bridge module for interacting with Google Fit
       { source: "com.xiaomi.hm.health", steps: [] }
     ];
     ```
+    Step also support a optional config to get rawStep Data for detail usage.
+    ```
+    const dailyOptions = {
+        startDate: "2020-07-06T00:00:00.000Z",
+        endDate:  "2020-07-06T23:59:00.000Z",
+        // optional
+        configs:{
+        bucketTime: 15,
+        bucketUnit: 'MINUTE' | 'HOUR' | 'SECOND' | 'DAY'  // must all CAPITALIZE
+        }
+    }
+   ```
+   **Response:**
+   ```
+   // {bucketTime: 15, bucketUnit: 'MINUTE'}
+   [
+      { source: "com.google.android.gms:estimated_steps", 
+        steps: [
+        {
+          "date":"2019-07-06","value": 135
+        },
+        ],
+        rawSteps: [
+          {"endDate": 1594012101944, "startDate": 1594012041944, "steps": 13}, 
+          {"endDate": 1594020600000, "startDate": 1594020596034, "steps": 0}, 
+          {"endDate": 1594020693175, "startDate": 1594020600000, "steps": 24}, 
+          {"endDate": 1594068898912, "startDate": 1594068777409, "steps": 53}, 
+          {"endDate": 1594073158830, "startDate": 1594073066166, "steps": 45}
+        ]
+      },
+    ]
+    
+    // {bucketTime: 1, bucketUnit: 'DAY'}
+    [
+        { source: "com.google.android.gms:estimated_steps",
+            ...
+          rawSteps: [
+           {"endDate": 1594073158830, "startDate": 1594012041944, "steps": 135}
+          ]
+        }
+    ]
+    ```
 
 4. Retrieve Weights
 

--- a/android/src/main/java/com/reactnative/googlefit/GoogleFitModule.java
+++ b/android/src/main/java/com/reactnative/googlefit/GoogleFitModule.java
@@ -12,9 +12,12 @@ package com.reactnative.googlefit;
 
 import android.app.Activity;
 import android.content.pm.PackageManager;
+import android.os.Build;
 import android.util.Log;
 import java.util.ArrayList;
 import android.content.Intent;
+
+import androidx.annotation.RequiresApi;
 
 import com.facebook.react.bridge.Arguments;
 import com.facebook.react.bridge.Callback;
@@ -129,23 +132,14 @@ public class GoogleFitModule extends ReactContextBaseJavaModule implements Lifec
     }
 
     @ReactMethod
-    public void getDailySteps(double startDay, double endDay) {
-        mGoogleFitManager.getStepHistory().displayLastWeeksData((long) startDay, (long) endDay);
-    }
-
-    @ReactMethod
-    public void getWeeklySteps(double startDate, double endDate) {
-        mGoogleFitManager.getStepHistory().displayLastWeeksData((long) startDate, (long) endDate);
-    }
-
-    @ReactMethod
     public void getDailyStepCountSamples(double startDate,
                                          double endDate,
+                                         ReadableMap configs,
                                          Callback errorCallback,
                                          Callback successCallback) {
 
         try {
-            mGoogleFitManager.getStepHistory().aggregateDataByDate((long) startDate, (long) endDate, successCallback);
+            mGoogleFitManager.getStepHistory().aggregateDataByDate((long) startDate, (long) endDate, configs, successCallback);
         } catch (IllegalViewOperationException e) {
             errorCallback.invoke(e.getMessage());
         }
@@ -417,6 +411,7 @@ public class GoogleFitModule extends ReactContextBaseJavaModule implements Lifec
         }
     }
 
+    @RequiresApi(api = Build.VERSION_CODES.N)
     @ReactMethod
     public void getSleepData(double startDate, double endDate, Callback errorCallback, Callback successCallback) {
         try {

--- a/index.android.d.ts
+++ b/index.android.d.ts
@@ -20,9 +20,18 @@ declare module 'react-native-google-fit' {
      */
     startRecording: (callback: (param: any) => void, dataTypes: Array<string>) => void
 
-    getSteps(dayStart: Date | string, dayEnd: Date | string): any
+    /**
+     * A shortcut to get the total steps of a given day by using getDailyStepCountSamples
+     * @param {Date} date optional param, new Date() will be used if date is not provided
+     */
+    getDailySteps: (date?: Date) => Promise<any>
 
-    getWeeklySteps(startDate: Date | string): any
+    /**
+     * A shortcut to get the weekly steps of a given day by using getDailyStepCountSamples
+     * @param {Date} date optional param, new Date() will be used if date is not provided
+     * @param {number} adjustment, optional param, use to adjust the default start day of week, 0 = Sunday, 1 = Monday, etc.
+     */
+    getWeeklySteps: (date?: Date, adjustment?: number) => Promise<any>
 
     /**
      * Get the total steps per day over a specified date range.
@@ -32,7 +41,7 @@ declare module 'react-native-google-fit' {
     getDailyStepCountSamples: (
       options: any,
       callback?: (isError: boolean, result: any) => void
-    ) => Promise<any> | void
+    ) => Promise<any>
 
     buildDailySteps(steps: any): { date: any; value: any }[]
 
@@ -41,6 +50,14 @@ declare module 'react-native-google-fit' {
      * @param {Object} options getDailyDistanceSamples accepts an options object containing required startDate: ISO8601Timestamp and endDate: ISO8601Timestamp.
      * @callback {Function} callback The function will be called with an array of elements.
      */
+
+
+ /**
+ * a exampleFunction description.
+ * @param {string} input
+ */
+ exampleFunction(input?: string) : void
+
     getDailyDistanceSamples(
       options: any,
       callback: (isError: boolean, result: any) => void

--- a/index.android.js
+++ b/index.android.js
@@ -165,10 +165,16 @@ class RNGoogleFit {
     return this.getDailyStepCountSamples(options);
   }
 
-  _retrieveDailyStepCountSamples = (startDate, endDate, callback) => {
+  isConfigsEmpty(obj) {
+    for(var prop in obj) return false;
+    return true;
+  }
+
+  _retrieveDailyStepCountSamples = (startDate, endDate, options, callback) => {
     googleFit.getDailyStepCountSamples(
       startDate,
       endDate,
+      options.configs,
       msg => callback(msg, false),
       res => {
         if (res.length > 0) {
@@ -180,6 +186,7 @@ class RNGoogleFit {
                 dev.source.appPackage +
                 (dev.source.stream ? ':' + dev.source.stream : '')
               obj.steps = buildDailySteps(dev.steps)
+              obj.rawSteps = this.isConfigsEmpty(options.configs) ? [] : dev.steps
               return obj
             }, this)
           )
@@ -208,6 +215,7 @@ class RNGoogleFit {
         this._retrieveDailyStepCountSamples(
           startDate,
           endDate,
+          options,
           (error, result) => {
             if (!error) {
               resolve(result)
@@ -218,7 +226,7 @@ class RNGoogleFit {
         )
       })
     }
-    this._retrieveDailyStepCountSamples(startDate, endDate, callback)
+    this._retrieveDailyStepCountSamples(startDate, endDate, options, callback)
   }
 
   /**

--- a/index.android.js
+++ b/index.android.js
@@ -1,5 +1,6 @@
 'use strict'
 import { DeviceEventEmitter, NativeModules, PermissionsAndroid } from 'react-native';
+import moment from 'moment';
 
 import PossibleScopes from './src/scopes';
 import {
@@ -140,12 +141,12 @@ class RNGoogleFit {
 
   /**
    * A shortcut to get the total steps of a given day by using getDailyStepCountSamples
-   * @param {Date} date optional param, new Date() will be used if date is not provided
+   * @param {Date} date optional param, new moment() will be used if date is not provided
    */
-  getDailySteps(date = new Date()) {
+  getDailySteps(date = moment()) {
     const options = {
-      startDate: new Date(date.setHours(0,0,0,0)).toISOString(), // required ISO8601Timestamp
-      endDate: new Date(date.setHours(23,59,59,999)).toISOString(), // required ISO8601Timestamp
+      startDate: moment(date).startOf('day'),
+      endDate: moment(date).endOf('day'),
     };
     return this.getDailyStepCountSamples(options);
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -73,6 +73,18 @@ function getFormattedDate(date) {
   return year + '-' + month + '-' + day
 }
 
+/***
+* avoid month boundary issue by using millisecond calculation
+* moment.js can be used as easy alternative
+*/
+export function getWeekBoundary(date, adjustment) {
+  const dayMilliseconds = 24 * 60 * 60 * 1000;
+  const currentWeekDay = date.getDay() - adjustment % 7;
+  const startDate = new Date(date.setHours(0,0,0,0) - dayMilliseconds * currentWeekDay);
+  const endDate = new Date(startDate.getTime() + dayMilliseconds * 7 -1);
+  return [startDate, endDate];
+}
+
 export function prepareDeleteOptions(options) {
   return {
     ...options,

--- a/src/utils.js
+++ b/src/utils.js
@@ -75,13 +75,21 @@ function getFormattedDate(date) {
 
 /***
 * avoid month boundary issue by using millisecond calculation
-* moment.js can be used as easy alternative
+* TimeZone Issue
+* moment.js can be used as better alternative
 */
+
+// export function getWeekBoundary(date, adjustment) {
+//   const dayMilliseconds = 24 * 60 * 60 * 1000;
+//   const currentWeekDay = date.getDay() - adjustment % 7;
+//   const startDate = new Date(date.setHours(0,0,0,0) - dayMilliseconds * currentWeekDay);
+//   const endDate = new Date(startDate.getTime() + dayMilliseconds * 7 -1);
+//   return [startDate, endDate];
+// }
+
 export function getWeekBoundary(date, adjustment) {
-  const dayMilliseconds = 24 * 60 * 60 * 1000;
-  const currentWeekDay = date.getDay() - adjustment % 7;
-  const startDate = new Date(date.setHours(0,0,0,0) - dayMilliseconds * currentWeekDay);
-  const endDate = new Date(startDate.getTime() + dayMilliseconds * 7 -1);
+  const startDate = moment(date).startOf('week').add(adjustment, 'days');
+  const endDate = moment(date).endOf('week').add(adjustment, 'days');
   return [startDate, endDate];
 }
 


### PR DESCRIPTION
Just fewer update to further enhance StepHistory.
1. Remove deprecated week and day method from java file since they all migrated to Javascript previously, are not accessible anywhere even in the past.
2. Fix existing date issue with `getdaily/weeklyStep`, which will return inaccurate step data. The default always respect to your local timezone.
3. Migrated deprecated step api to standard api.

New feature: 

`rawSteps` is introduced to tackle some issues #167, #160, 

`options` for `getDailyStepCountSamples`, `getdaily/weeklyStep` now has a options config to get details based on your need
For instance:

      const dailyOptions = {
        startDate: moment(today).startOf('day'),
        endDate: moment(today).endOf('day'),
        // configs:{
        //   bucketTime: 15,
        //   bucketUnit: 'MINUTE' | 'HOUR' | 'SECOND' | 'DAY'  // must CAPITALIZE
        // }
      }

`bucketUnit` is self-explanatory, 
`bucketTime` refers to how details you want to extract your data. the smaller, data will be chunk down by your bucket.

**WARNING**, please down abuse this feat. **with small bucket with long range of days.** 
     `configs: {  bucketTime: 1,   bucketUnit: 'SECOND'  }` can easily stuck your app if you give a big time range because of the amount of data you are going to receive.

For details: https://developers.google.com/android/reference/com/google/android/gms/fitness/data/Bucket


If`{ bucketTime: 1, bucketUnit: 'DAY' }` the response would look like the following:


```
[
  { source: "com.google.android.gms:estimated_steps", 
    steps: [
    {
      "date":"2019-07-06","value": 135
    },
    ]
    rawSteps: [
       {"endDate": 1594073158830, "startDate": 1594012041944, "steps": 135}
    ]
  },
```

If`{ bucketTime: 15, bucketUnit: 'MINUTE' }`

```
[
  { source: "com.google.android.gms:estimated_steps", 
    steps: [
    {
      "date":"2019-07-06","value": 135
    },
    ],
    rawSteps: [
      {"endDate": 1594012101944, "startDate": 1594012041944, "steps": 13}, 
      {"endDate": 1594020600000, "startDate": 1594020596034, "steps": 0}, 
      {"endDate": 1594020693175, "startDate": 1594020600000, "steps": 24}, 
      {"endDate": 1594068898912, "startDate": 1594068777409, "steps": 53}, 
      {"endDate": 1594073158830, "startDate": 1594073066166, "steps": 45}
    ]
  },
```

As the variable name says, it's rawData, please handle them by yourself, after parse from above, you are likely to have something like 
![image](https://user-images.githubusercontent.com/35160613/86676133-4c23cb00-bfc8-11ea-97c1-f848ebe9f80d.png)

README.md is not updated yet.


