### PR TITLE
update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -475,8 +475,15 @@ A React Native bridge module for interacting with Google Fit
       console.log(res);
     });
     ```
+    
+15. Retrieve Sleep 
+    ```javascript
+        GoogleFit.getSleepData(options, (err, res) => {
+      console.log(res)
+    });
+    ```
 
-15. Other methods:
+16. Other methods:
 
     ```javascript
     observeSteps(callback); // On Step Changed Event


### PR DESCRIPTION
since `bucketInterval` is used for all functions. old step doc is not longer viable,
and add sleep function to doc.