### PR TITLE
Handle permissions exception for google fit

### DIFF
--- a/android/src/main/java/com/reactnative/googlefit/SleepHistory.java
+++ b/android/src/main/java/com/reactnative/googlefit/SleepHistory.java
@@ -32,6 +32,7 @@ import com.google.android.gms.common.api.ResultCallback;
 import com.google.android.gms.common.api.Scope;
 import com.google.android.gms.fitness.Fitness;
 import com.google.android.gms.fitness.FitnessActivities;
+import com.google.android.gms.fitness.FitnessOptions;
 import com.google.android.gms.fitness.data.Bucket;
 import com.google.android.gms.fitness.data.DataPoint;
 import com.google.android.gms.fitness.data.DataSet;
@@ -69,7 +70,8 @@ public class SleepHistory {
     private GoogleFitManager googleFitManager;
 
     private static final String TAG = "RNGoogleFit-Sleep";
-
+    private static final String sleepPermissionsError = "4: The user must be signed in to make this API call.";
+    private static final Int sleepErrorCode = 4;
     public SleepHistory(ReactContext reactContext, GoogleFitManager googleFitManager){
         this.mReactContext = reactContext;
         this.googleFitManager = googleFitManager;
@@ -117,9 +119,21 @@ public class SleepHistory {
                     @Override
                     public void onFailure(@NonNull Exception e) {
                         Log.i(TAG, "Failure: " + e.getMessage());
-                        errorCallback.invoke(e.getMessage());
+                        if (sleepPermissionsError.equals(e.getMessage())) {
+                            requestSleepPermissions(gsa);
+                            errorCallback.invoke(sleepPermissionsError);
+                        } else {
+                            errorCallback.invoke(e.getMessage());
+                        }
                     }
                 });
+    }
+
+    void requestSleepPermissions(GoogleSignInAccount account) {
+        FitnessOptions fitnessOptions = FitnessOptions.builder()
+                .addDataType(DataType.TYPE_ACTIVITY_SEGMENT, FitnessOptions.ACCESS_READ)
+                .build();
+        GoogleSignIn.requestPermissions(this.mReactContext.getCurrentActivity(), sleepErrorCode, account, fitnessOptions);
     }
 
     private void processDataSet(DataSet dataSet, Session session, WritableArray map) {

--- a/android/src/main/java/com/reactnative/googlefit/SleepHistory.java
+++ b/android/src/main/java/com/reactnative/googlefit/SleepHistory.java
@@ -71,7 +71,7 @@ public class SleepHistory {
 
     private static final String TAG = "RNGoogleFit-Sleep";
     private static final String sleepPermissionsError = "4: The user must be signed in to make this API call.";
-    private static final Int sleepErrorCode = 4;
+    private static final int sleepErrorCode = 4;
     public SleepHistory(ReactContext reactContext, GoogleFitManager googleFitManager){
         this.mReactContext = reactContext;
         this.googleFitManager = googleFitManager;
@@ -85,7 +85,7 @@ public class SleepHistory {
                 .setTimeInterval((long) startDate, (long) endDate, TimeUnit.MILLISECONDS)
                 .build();
 
-        GoogleSignInAccount gsa = GoogleSignIn.getAccountForScopes(this.mReactContext, new Scope(Scopes.FITNESS_ACTIVITY_READ));
+        final GoogleSignInAccount gsa = GoogleSignIn.getAccountForScopes(this.mReactContext, new Scope(Scopes.FITNESS_ACTIVITY_READ));
         Fitness.getSessionsClient(this.mReactContext, gsa)
                 .readSession(request)
                 .addOnSuccessListener(new OnSuccessListener<SessionReadResponse>() {


### PR DESCRIPTION
**This PR includes code to handle an exception that prevents users to read sleep data, in some scenarios google fit is not able to read sleep records.**

when the app is facing for this error, google fit response  `4: The user must be signed in to make this API call.` as error message, after some research, we figured out that was possible to request specific permission by using `GoogleSignIn.requestPermissions`,  so following that way we were able to fix this issue by requesting permissions when the app turns on that error.

we also figured out that the app gets this error after we manually removed the permission from Google fit app, in that scenario after we remove the permissions and we back to the app and started the sync process google fit was not able to get all the required permission. 

`GoogleSignIn.hasPermissions` always return `true` even if the app was facing the permissions issue, by that inconvenient we decide to place the request for the permission in to the `onFailure` since it was being properly catch only from there.