### PR TITLE
Add heart rate scopes

### DIFF
--- a/src/scopes.js
+++ b/src/scopes.js
@@ -39,6 +39,10 @@ const fitnessScopes = {
     'https://www.googleapis.com/auth/fitness.sleep.read',
   FITNESS_SLEEP_WRITE:
     'https://www.googleapis.com/auth/fitness.sleep.write',
+  FITNESS_HEART_RATE_READ:
+    'https://www.googleapis.com/auth/fitness.heart_rate.read',
+  FITNESS_HEART_RATE_WRITE:
+    'https://www.googleapis.com/auth/fitness.heart_rate.write'
 }
 
 export default fitnessScopes


### PR DESCRIPTION
Hi there, I have found that requesting heart rate data requires the heart rate scopes.
I was getting only an empty array for heart rate and decided to debug with Android Studio's logcat, there I saw this message:

`2021-01-25 15:27:56.381 24173-12564/? W/Fitness: Failed to authenticate com.pruebareact: Status{statusCode=Application needs OAuth consent from the user, resolution=PendingIntent{9cb3585: android.os.BinderProxy@fb27fda}} [CONTEXT service_id=17 ]
`

So I went to [https://developers.google.com/fit/datatypes#authorization_scopes](url) and manually added 'https://www.googleapis.com/auth/fitness.heart_rate.read' to the `options.scopes` and everything worked fine!

I'm not sure if this is something new with Google Fit API, but it's the only way I could get this data. Other kinds of data like steps and sleep works very well.