### PR TITLE
Add device info to the data when available

### DIFF
--- a/android/src/main/java/com/reactnative/googlefit/HelperUtil.java
+++ b/android/src/main/java/com/reactnative/googlefit/HelperUtil.java
@@ -51,6 +51,19 @@ final class HelperUtil {
         return signInOptionsExtension.build();
     }
 
+    public static String getDeviceType(Device device) {
+        switch (device.getType()) {
+            case Device.TYPE_PHONE: return "phone";
+            case Device.TYPE_WATCH: return "watch";
+            case Device.TYPE_TABLET: return "tablet";
+            case Device.TYPE_CHEST_STRAP: return "chest-strap";
+            case Device.TYPE_HEAD_MOUNTED: return "head-mounted";
+            case Device.TYPE_SCALE: return "scale";
+            case Device.TYPE_UNKNOWN: return "unknown";
+        }; 
+        return "unknown";
+    }
+
     public static void processDataSet(String TAG, DataSet dataSet, WritableArray wtArray) {
         DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
         dateFormat.setTimeZone(TimeZone.getDefault());
@@ -76,32 +89,7 @@ final class HelperUtil {
                     innerMap.putString("deviceUid", device.getUid());
                     innerMap.putString("deviceManufacturer", device.getManufacturer());
                     innerMap.putString("deviceModel", device.getModel());
-                    switch (device.getType()) {
-                        case Device.TYPE_PHONE:  
-                            innerMap.putString("deviceType", "phone");
-                        break;
-                        case Device.TYPE_WATCH: 
-                            innerMap.putString("deviceType", "watch");
-                        break;
-                        case Device.TYPE_TABLET: 
-                            innerMap.putString("deviceType", "tablet");
-                        break;
-                        case Device.TYPE_CHEST_STRAP:
-                            innerMap.putString("deviceType", "chest-strap");
-                        break;
-                        case Device.TYPE_HEAD_MOUNTED:
-                            innerMap.putString("deviceType", "head-mounted");
-                        break;
-                        case Device.TYPE_SCALE:
-                            innerMap.putString("deviceType", "scale");
-                        break;
-                        case Device.TYPE_UNKNOWN:
-                            innerMap.putString("deviceType", "unknown");
-                        break;
-                        default: 
-                            innerMap.putString("deviceType", "unknown");
-                        break;
-                    };
+                    innerMap.putString("deviceType", getDeviceType(device));
                 }
 
                 innerMap.putDouble("startDate", dp.getStartTime(TimeUnit.MILLISECONDS));

--- a/android/src/main/java/com/reactnative/googlefit/HelperUtil.java
+++ b/android/src/main/java/com/reactnative/googlefit/HelperUtil.java
@@ -10,6 +10,7 @@ import com.google.android.gms.fitness.FitnessOptions;
 import com.google.android.gms.fitness.data.DataPoint;
 import com.google.android.gms.fitness.data.DataSet;
 import com.google.android.gms.fitness.data.DataType;
+import com.google.android.gms.fitness.data.Device;
 import com.google.android.gms.fitness.data.Field;
 import com.google.android.gms.fitness.request.DataReadRequest;
 
@@ -69,6 +70,40 @@ final class HelperUtil {
                 innerMap.putString("dataTypeName", dp.getDataType().getName());
                 innerMap.putString("dataSourceId", dp.getDataSource().getStreamIdentifier());
                 innerMap.putString("originDataSourceId", dp.getOriginalDataSource().getStreamIdentifier());
+
+                Device device = dp.getOriginalDataSource().getDevice();
+                if (device != null) {
+                    innerMap.putString("deviceUid", device.getUid());
+                    innerMap.putString("deviceManufacturer", device.getManufacturer());
+                    innerMap.putString("deviceModel", device.getModel());
+                    switch (device.getType()) {
+                        case Device.TYPE_PHONE:  
+                            innerMap.putString("deviceType", "phone");
+                        break;
+                        case Device.TYPE_WATCH: 
+                            innerMap.putString("deviceType", "watch");
+                        break;
+                        case Device.TYPE_TABLET: 
+                            innerMap.putString("deviceType", "tablet");
+                        break;
+                        case Device.TYPE_CHEST_STRAP:
+                            innerMap.putString("deviceType", "chest-strap");
+                        break;
+                        case Device.TYPE_HEAD_MOUNTED:
+                            innerMap.putString("deviceType", "head-mounted");
+                        break;
+                        case Device.TYPE_SCALE:
+                            innerMap.putString("deviceType", "scale");
+                        break;
+                        case Device.TYPE_UNKNOWN:
+                            innerMap.putString("deviceType", "unknown");
+                        break;
+                        default: 
+                            innerMap.putString("deviceType", "unknown");
+                        break;
+                    };
+                }
+
                 innerMap.putDouble("startDate", dp.getStartTime(TimeUnit.MILLISECONDS));
                 innerMap.putDouble("endDate", dp.getEndTime(TimeUnit.MILLISECONDS));
                 innerMap.putDouble(field.getName(), dp.getValue(field).asInt());

--- a/android/src/main/java/com/reactnative/googlefit/StepHistory.java
+++ b/android/src/main/java/com/reactnative/googlefit/StepHistory.java
@@ -175,32 +175,7 @@ public class StepHistory {
                 source.putString("deviceUid", device.getUid());
                 source.putString("deviceManufacturer", device.getManufacturer());
                 source.putString("deviceModel", device.getModel());
-                switch(device.getType()) {
-                    case Device.TYPE_PHONE:  
-                        source.putString("deviceType", "phone");
-                    break;
-                    case Device.TYPE_WATCH: 
-                        source.putString("deviceType", "watch");
-                    break;
-                    case Device.TYPE_TABLET: 
-                        source.putString("deviceType", "tablet");
-                    break;
-                    case Device.TYPE_CHEST_STRAP:
-                        source.putString("deviceType", "chest-strap");
-                    break;
-                    case Device.TYPE_HEAD_MOUNTED:
-                        source.putString("deviceType", "head-mounted");
-                    break;
-                    case Device.TYPE_SCALE:
-                        source.putString("deviceType", "scale");
-                    break;
-                    case Device.TYPE_UNKNOWN:
-                        source.putString("deviceType", "unknown");
-                    break;
-                    default: 
-                        source.putString("deviceType", "unknown");
-                    break;
-                }
+                source.putString("deviceType", HelperUtil.getDeviceType(device));
             }
 
             //if (!DataType.TYPE_STEP_COUNT_DELTA.equals(type)) continue;

--- a/android/src/main/java/com/reactnative/googlefit/StepHistory.java
+++ b/android/src/main/java/com/reactnative/googlefit/StepHistory.java
@@ -172,16 +172,35 @@ public class StepHistory {
 
             Log.i(TAG, "  + Device    : " + device);
             if (device != null) {
+                source.putString("deviceUid", device.getUid());
                 source.putString("deviceManufacturer", device.getManufacturer());
                 source.putString("deviceModel", device.getModel());
                 switch(device.getType()) {
+                    case Device.TYPE_PHONE:  
+                        source.putString("deviceType", "phone");
+                    break;
+                    case Device.TYPE_WATCH: 
+                        source.putString("deviceType", "watch");
+                    break;
+                    case Device.TYPE_TABLET: 
+                        source.putString("deviceType", "tablet");
+                    break;
                     case Device.TYPE_CHEST_STRAP:
-                        source.putString("deviceType", "chestStrap"); break;
+                        source.putString("deviceType", "chest-strap");
+                    break;
+                    case Device.TYPE_HEAD_MOUNTED:
+                        source.putString("deviceType", "head-mounted");
+                    break;
+                    case Device.TYPE_SCALE:
+                        source.putString("deviceType", "scale");
+                    break;
+                    case Device.TYPE_UNKNOWN:
+                        source.putString("deviceType", "unknown");
+                    break;
+                    default: 
+                        source.putString("deviceType", "unknown");
+                    break;
                 }
-            } else {
-                source.putNull("deviceManufacturer");
-                source.putNull("deviceModel");
-                source.putNull("deviceType");
             }
 
             //if (!DataType.TYPE_STEP_COUNT_DELTA.equals(type)) continue;

--- a/index.android.d.ts
+++ b/index.android.d.ts
@@ -276,7 +276,18 @@ declare module 'react-native-google-fit' {
     bucketUnit: BucketUnit
   };
 
-  type rawSteps = Array<{startDate: string, endDate: string, steps: number}>;
+  type rawSteps = Array<{
+    dataTypeName: string,
+    dataSourceId: string,
+    originDataSourceId: string,
+    deviceUid?: string,
+    deviceManufacturer?: string,
+    deviceModel?: string,
+    deviceType?: string,
+    startDate: string,
+    endDate: number,
+    steps: number
+  }>;
 
   export type StepsResponse = {
     source: string,

--- a/index.android.d.ts
+++ b/index.android.d.ts
@@ -276,7 +276,7 @@ declare module 'react-native-google-fit' {
     bucketUnit: BucketUnit
   };
 
-  type rawSteps = Array<{
+  export type DeviceInfo = {
     dataTypeName: string,
     dataSourceId: string,
     originDataSourceId: string,
@@ -284,15 +284,18 @@ declare module 'react-native-google-fit' {
     deviceManufacturer?: string,
     deviceModel?: string,
     deviceType?: string,
-    startDate: string,
+  }
+
+  export type RawStep = {
+    startDate: number,
     endDate: number,
     steps: number
-  }>;
+  } & DeviceInfo;
 
   export type StepsResponse = {
     source: string,
     steps: Array<{date: string, value: number }>,
-    rawSteps: rawSteps
+    rawSteps: RawStep[]
   };
 
   export type CalorieResponse = {


### PR DESCRIPTION
When trying this library with Google Fit and my smart watch, I noticed that the returned steps data does not have any device info available.

Depending on where the data comes from, the device information can be found by calling `dp.getOriginalDataSource().getDevice()`. This PR adds that information to the response when available.

To me it looks like the Typescript types in the current version are not up-to-date, so I tried updating them, but I'm not sure if I did it correctly. Please let me know if you think that they are not correct.

P.S.

There are also other fields that could be added with a separate Pull Request, e.g. `dp.getOriginalDataSource().getAppPackageName()` and the `appName` when the data comes from a third-party app, such as Withings Health Mate or Polar Flow.

@aboveyunhai
