### PR TITLE
Add app info to the data

### DIFF
--- a/android/src/main/java/com/reactnative/googlefit/ActivityHistory.java
+++ b/android/src/main/java/com/reactnative/googlefit/ActivityHistory.java
@@ -201,7 +201,7 @@ public class ActivityHistory {
             if (response.getStatus().isSuccess()) {
                 for (Bucket bucket : response.getBuckets()) {
                     for (DataSet dataSet : bucket.getDataSets()) {
-                        HelperUtil.processDataSet(TAG, dataSet, moveMinutes);
+                        HelperUtil.processDataSet(this.mReactContext, TAG, dataSet, moveMinutes);
                     }
                 }
                 return moveMinutes;

--- a/android/src/main/java/com/reactnative/googlefit/HelperUtil.java
+++ b/android/src/main/java/com/reactnative/googlefit/HelperUtil.java
@@ -1,8 +1,12 @@
 package com.reactnative.googlefit;
 
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+import android.content.pm.PackageManager.NameNotFoundException;
 import android.util.Log;
 
 import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 import com.google.android.gms.auth.api.signin.GoogleSignInOptionsExtension;
@@ -51,6 +55,16 @@ final class HelperUtil {
         return signInOptionsExtension.build();
     }
 
+    public static String getAppName(PackageManager pm, String packageName) {
+        ApplicationInfo ai = null;
+        try {
+            ai = pm.getApplicationInfo(packageName, 0);
+        } catch (final NameNotFoundException e) {
+            return null;
+        }
+        return (String) pm.getApplicationLabel(ai);
+    }
+
     public static String getDeviceType(Device device) {
         switch (device.getType()) {
             case Device.TYPE_PHONE: return "phone";
@@ -64,7 +78,7 @@ final class HelperUtil {
         return "unknown";
     }
 
-    public static void processDataSet(String TAG, DataSet dataSet, WritableArray wtArray) {
+    public static void processDataSet(ReactContext reactContext, String TAG, DataSet dataSet, WritableArray wtArray) {
         DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
         dateFormat.setTimeZone(TimeZone.getDefault());
 
@@ -83,6 +97,16 @@ final class HelperUtil {
                 innerMap.putString("dataTypeName", dp.getDataType().getName());
                 innerMap.putString("dataSourceId", dp.getDataSource().getStreamIdentifier());
                 innerMap.putString("originDataSourceId", dp.getOriginalDataSource().getStreamIdentifier());
+
+                String appPackageName = dp.getOriginalDataSource().getAppPackageName();
+                if (appPackageName != null) {
+                    innerMap.putString("appPackageName", appPackageName);
+                    PackageManager pm = reactContext.getPackageManager();
+                    String appName = getAppName(pm, appPackageName);
+                    if (appName != null) {
+                        innerMap.putString("appName", appName);
+                    }
+                }
 
                 Device device = dp.getOriginalDataSource().getDevice();
                 if (device != null) {

--- a/android/src/main/java/com/reactnative/googlefit/StepHistory.java
+++ b/android/src/main/java/com/reactnative/googlefit/StepHistory.java
@@ -226,7 +226,7 @@ public class StepHistory {
                                 for (Bucket bucket : dataReadResponse.getBuckets()) {
                                     List<DataSet> dataSets = bucket.getDataSets();
                                     for (DataSet dataSet : dataSets) {
-                                        HelperUtil.processDataSet(TAG, dataSet, steps);
+                                        HelperUtil.processDataSet(mReactContext, TAG, dataSet, steps);
                                     }
                                 }
                             }
@@ -235,7 +235,7 @@ public class StepHistory {
                             if (dataReadResponse.getDataSets().size() > 0) {
                                 Log.i(TAG, "  +++ Number of returned DataSets: " + dataReadResponse.getDataSets().size());
                                 for (DataSet dataSet : dataReadResponse.getDataSets()) {
-                                    HelperUtil.processDataSet(TAG, dataSet, steps);
+                                    HelperUtil.processDataSet(mReactContext, TAG, dataSet, steps);
                                 }
                             }
 

--- a/index.android.d.ts
+++ b/index.android.d.ts
@@ -277,6 +277,8 @@ declare module 'react-native-google-fit' {
   };
 
   export type DeviceInfo = {
+    appName?: string,
+    appPackageName?: string,
     dataTypeName: string,
     dataSourceId: string,
     originDataSourceId: string,


### PR DESCRIPTION
In my previous Pull Request I added device information to the data when it is available. The fit data might not be synced from a device directly, but instead from a 3rd party app. In that case it would be useful to know from which app the data is coming from.

This Pull Request adds a call to `dp.getOriginalDataSource().getAppPackageName()` to get the source's app package name if available. In the case where the package name is set, we can use the package manager to get the name of that app.

I tested these changes with my test app and the Withings Health Mate app, and here is how the data looks like.

**Data from Withings watch and the Health Mate app installed:**

```js
appName: "Health Mate",
appPackageName: "com.withings.wiscale2",
...
```

**Data from Withings watch and no app installed (`appName` is not set):**

```js
appPackageName: "com.withings.wiscale2",
...
```

In the case where the data comes directly from a device (e.g. phone's step counter), the `appName` and `appPackageName` fields are not set but there is info about the device instead.

I'm not very good at writing Java, so please let me know if there is some cleaner way of getting a reference to the package manager or other things.

@aboveyunhai
