### PR TITLE
Update AndroidManifest.xml

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.reactnative.googlefit">
+
+    <queries>
+      <package android:name="com.google.android.apps.fitness" />
+    </queries>
+
 </manifest>


### PR DESCRIPTION
Some functions such as `openFit()` and `isAvailable(callback)` didn't work on Android 11 for apps built with Expo.

This is simply because `queries` does not contain [Google Fit](https://github.com/StasDoskalenko/react-native-google-fit#android-11
), but the issue is adding an item to `queries` is not so easy for Expo projects.

I am not sure how non-expo projects work, but it would be nice see Google Fit added to the `query` in the `AndroidManifest.xml` if this doesn't affect non-Expo projects.