### PR TITLE
Flag manually added data on CalorieHistory & HealthHistory

### DIFF
--- a/android/src/main/java/com/reactnative/googlefit/CalorieHistory.java
+++ b/android/src/main/java/com/reactnative/googlefit/CalorieHistory.java
@@ -164,6 +164,16 @@ public class CalorieHistory {
                     }
                 }
                 stepMap.putDouble("calorie", dp.getValue(field).asFloat() - basal);
+
+                /** Checks is data point was added manually by user */
+                DataSource ds = dp.getOriginalDataSource();
+                String streamId = ds.getStreamIdentifier();
+                if (streamId.toLowerCase().indexOf("user_input") != -1) {
+                    stepMap.putBoolean("wasManuallyEntered", true);
+                } else {
+                    stepMap.putBoolean("wasManuallyEntered", false);
+                }
+                
                 map.pushMap(stepMap);
             }
         }

--- a/android/src/main/java/com/reactnative/googlefit/CalorieHistory.java
+++ b/android/src/main/java/com/reactnative/googlefit/CalorieHistory.java
@@ -165,7 +165,7 @@ public class CalorieHistory {
                 }
                 stepMap.putDouble("calorie", dp.getValue(field).asFloat() - basal);
 
-                /** Checks is data point was added manually by user */
+                /** Checks if data point was added manually by user */
                 DataSource ds = dp.getOriginalDataSource();
                 String streamId = ds.getStreamIdentifier();
                 if (streamId.toLowerCase().indexOf("user_input") != -1) {

--- a/android/src/main/java/com/reactnative/googlefit/HealthHistory.java
+++ b/android/src/main/java/com/reactnative/googlefit/HealthHistory.java
@@ -287,7 +287,7 @@ public class HealthHistory {
                   stepMap.putDouble("value", dp.getValue(field).asFloat());
                 }
 
-                /** Checks is data point was added manually by user */
+                /** Checks if data point was added manually by user */
                 DataSource ds = dp.getOriginalDataSource();
                 String streamId = ds.getStreamIdentifier();
                 if (streamId.toLowerCase().indexOf("user_input") != -1) {

--- a/android/src/main/java/com/reactnative/googlefit/HealthHistory.java
+++ b/android/src/main/java/com/reactnative/googlefit/HealthHistory.java
@@ -287,6 +287,14 @@ public class HealthHistory {
                   stepMap.putDouble("value", dp.getValue(field).asFloat());
                 }
 
+                /** Checks is data point was added manually by user */
+                DataSource ds = dp.getOriginalDataSource();
+                String streamId = ds.getStreamIdentifier();
+                if (streamId.toLowerCase().indexOf("user_input") != -1) {
+                    stepMap.putBoolean("wasManuallyEntered", true);
+                } else {
+                    stepMap.putBoolean("wasManuallyEntered", false);
+                }
 
                 map.pushMap(stepMap);
             }

--- a/index.android.d.ts
+++ b/index.android.d.ts
@@ -321,7 +321,8 @@ declare module 'react-native-google-fit' {
     calorie: number,
     endDate: string,
     startDate: string,
-    day: Day
+    day: Day,
+    wasManuallyEntered: boolean;
   };
 
   export type DistanceResponse = {
@@ -335,7 +336,8 @@ declare module 'react-native-google-fit' {
     startDate: string,
     endDate: string,
     value: number,
-    day: Day
+    day: Day,
+    wasManuallyEntered: boolean
   };
 
   export type BloodPressureResponse = {

--- a/index.android.d.ts
+++ b/index.android.d.ts
@@ -345,28 +345,32 @@ declare module 'react-native-google-fit' {
     endDate: string,
     diastolic: number,
     systolic: number,
-    day: Day
+    day: Day,
+    wasManuallyEntered: boolean
   }
 
   export type BloodGlucoseResponse = {
     startDate: string,
     endDate: string,
     value: number,
-    day: Day
+    day: Day,
+    wasManuallyEntered: boolean
   }
 
   export type BodyTemperatureResponse = {
     startDate: string,
     endDate: string,
     value: number,
-    day: Day
+    day: Day,
+    wasManuallyEntered: boolean
   }
 
   export type OxygenSaturationResponse = {
     startDate: string,
     endDate: string,
     value: number,
-    day: Day
+    day: Day,
+    wasManuallyEntered: boolean
   }
   
   export type WeightData = { date: string } & ({ unit: 'pound', value: number } | {});


### PR DESCRIPTION
This improvement allows methods related to the `HeathHistory` module and `CalorieHistory` module to return a key called `wasManuallyEntered` for each data point received. This tells us if the user has added that data directly in Google Fit ( in which case `wasManuallyEntered: true`), or if it was recorded with a sensor by a watch, band etc ( in which case `wasManuallyEntered: false`).  This is beneficial for cases when you need to get the actual data ( if you give rewards on workouts or you use it for some sort of competition ).

The methods that will benefit from this are: `getDailyCalorieSamples`,`getHeartRateSamples`, `getBloodPressureSamples`, `getBodyTemperatureSamples`, `getOxygenSaturationSamples`, `getBloodGlucoseSamples`.

A similar issue was reported in #39 , though it's old.
