### PR TITLE
Added the inLocalTimeZone parameter to the prepareResponse function.

### DIFF
--- a/android/src/main/java/com/reactnative/googlefit/GoogleFitModule.java
+++ b/android/src/main/java/com/reactnative/googlefit/GoogleFitModule.java
@@ -467,6 +467,22 @@ public class GoogleFitModule extends ReactContextBaseJavaModule implements Lifec
     }
 
     @ReactMethod
+    public void getAggregatedHeartRateSamples(double startDate,
+                                              double endDate,
+                                              int bucketInterval,
+                                              String bucketUnit,
+                                              Promise promise) {
+
+        try {
+            HealthHistory healthHistory = mGoogleFitManager.getHealthHistory();
+            healthHistory.setDataType(DataType.TYPE_HEART_RATE_BPM);
+            promise.resolve(healthHistory.getAggregatedHeartRateHistory((long)startDate, (long)endDate, bucketInterval, bucketUnit));
+        } catch (IllegalViewOperationException e) {
+            promise.reject(e);
+        }
+    }
+
+    @ReactMethod
     public void getRestingHeartRateSamples(double startDate,
                                     double endDate,
                                     int bucketInterval,

--- a/index.android.d.ts
+++ b/index.android.d.ts
@@ -181,9 +181,11 @@ declare module 'react-native-google-fit' {
     /**
      * Get the sleep sessions over a specified date range.
      * @param {Object} options getSleepData accepts an options object containing required startDate: ISO8601Timestamp and endDate: ISO8601Timestamp.
+     * @param inLocalTimeZone return start and end dates in local time zone rather than converting to UTC.
      */
     getSleepSamples: (
-      options: Partial<StartAndEndDate>
+      options: Partial<StartAndEndDate>,
+      inLocalTimeZone: boolean
     ) => Promise<SleepSampleResponse[]>
 
     saveSleep: (

--- a/index.android.d.ts
+++ b/index.android.d.ts
@@ -112,7 +112,8 @@ declare module 'react-native-google-fit' {
     ) => Promise<HeartRateResponse[]>;
 
     getAggregatedHeartRateSamples: (
-      options: StartAndEndDate & Partial<BucketOptions>
+      options: StartAndEndDate & Partial<BucketOptions>,
+      inLocalTimeZone: boolean
     ) => Promise<AggregatedHeartRateResponse[]>;
 
     /**

--- a/index.android.d.ts
+++ b/index.android.d.ts
@@ -111,6 +111,10 @@ declare module 'react-native-google-fit' {
       options: StartAndEndDate & Partial<BucketOptions>
     ) => Promise<HeartRateResponse[]>;
 
+    getAggregatedHeartRateSamples: (
+      options: StartAndEndDate & Partial<BucketOptions>
+    ) => Promise<AggregatedHeartRateResponse[]>;
+
     /**
      * Query for getting resting heart rate samples. the options object is used to setup a query to retrieve relevant samples.
      * @param {Object} options  getRestingHeartRateSamples accepts an options object startDate: ISO8601Timestamp and endDate: ISO8601Timestamp.
@@ -341,6 +345,15 @@ declare module 'react-native-google-fit' {
     day: Day,
     wasManuallyEntered: boolean
   };
+
+  export type AggregatedHeartRateResponse = {
+    startDate: string,
+    endDate: string,
+    min: number,
+    average: number,
+    max: number,
+    day: Day,
+  }
 
   export type BloodPressureResponse = {
     startDate: string,

--- a/index.android.js
+++ b/index.android.js
@@ -689,9 +689,10 @@ class RNGoogleFit {
   /**
    * Get the sleep sessions over a specified date range.
    * @param {Object} options getSleepData accepts an options object containing required startDate: ISO8601Timestamp and endDate: ISO8601Timestamp.
+   * @param inLocalTimeZone return start and end dates in local time zone rather than converting to UTC
    */
 
-  getSleepSamples = async (options) => {
+  getSleepSamples = async (options, inLocalTimeZone = false) => {
     const { startDate, endDate } = prepareInput(options);
 
     const result = await googleFit.getSleepSamples(
@@ -699,7 +700,7 @@ class RNGoogleFit {
       endDate
     );
 
-    return prepareResponse(result, "addedBy");
+    return prepareResponse(result, "addedBy", inLocalTimeZone);
   }
 
   saveSleep = async (options) => {

--- a/index.android.js
+++ b/index.android.js
@@ -567,7 +567,7 @@ class RNGoogleFit {
     return result;
   }
 
-  getAggregatedHeartRateSamples = async (options) => {
+  getAggregatedHeartRateSamples = async (options, inLocalTimeZone = false) => {
     const { startDate, endDate, bucketInterval, bucketUnit } = prepareInput(options);
     const result = await googleFit.getAggregatedHeartRateSamples(
       startDate,
@@ -576,7 +576,7 @@ class RNGoogleFit {
       bucketUnit
     );
     if (result.length > 0) {
-      return prepareResponse(result, 'average');
+      return prepareResponse(result, 'average', inLocalTimeZone);
     }
     return result;
   }

--- a/index.android.js
+++ b/index.android.js
@@ -567,6 +567,20 @@ class RNGoogleFit {
     return result;
   }
 
+  getAggregatedHeartRateSamples = async (options) => {
+    const { startDate, endDate, bucketInterval, bucketUnit } = prepareInput(options);
+    const result = await googleFit.getAggregatedHeartRateSamples(
+      startDate,
+      endDate,
+      bucketInterval,
+      bucketUnit
+    );
+    if (result.length > 0) {
+      return prepareResponse(result, 'average');
+    }
+    return result;
+  }
+
   getRestingHeartRateSamples = async (options) => {
     const { startDate, endDate, bucketInterval, bucketUnit } = prepareInput(options);
     const result = await googleFit.getRestingHeartRateSamples(

--- a/src/utils.js
+++ b/src/utils.js
@@ -48,7 +48,7 @@ export function prepareInput(options) {
   return { startDate, endDate, bucketInterval, bucketUnit };
 }
 
-export function prepareResponse(response, byKey = 'value') {
+export function prepareResponse(response, byKey = 'value', inLocalTimeZone = false) {
   return response
     .map(el => {
       if (!isNil(el[byKey])) {
@@ -57,8 +57,13 @@ export function prepareResponse(response, byKey = 'value') {
         // the Chrome V8 debugger, but not on device. Using momentJS here to get around this issue.
         // el.startDate = new Date(el.startDate).toISOString()
         // el.endDate = new Date(el.endDate).toISOString()
-        el.startDate = moment(el.startDate).toISOString()
-        el.endDate = moment(el.endDate).toISOString()
+        if (inLocalTimeZone) {
+          el.startDate = moment.parseZone(el.startDate).toISOString(true)
+          el.endDate = moment.parseZone(el.endDate).toISOString(true)
+        } else {
+          el.startDate = moment(el.startDate).toISOString()
+          el.endDate = moment(el.endDate).toISOString()
+        }
         return el
       }
     })


### PR DESCRIPTION
This defaults to false (existing behaviour) so is backwards compatible.

When inLocalTimeZone = false, dates are returned in the format: "endDate":"2022-12-22T16:51:30.000Z" When inLocalTimeZone = true, dates are returned in the format: "endDate":"2022-12-22T11:51:30.000-0500"

This allows performance improvements, because you don't have to perform further date processing on the values to convert them back into the local time zone.

This PR adds the flag as a parameter to getSleepSamples. It can easily be added to other functions as required.