### PR TITLE
Use AndroidX

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.1'
+        classpath 'com.android.tools.build:gradle:8.0.2'
     }
 }
 
@@ -17,8 +17,30 @@ def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
 
+def supportsNamespace() {
+    def parsed = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')
+    def major = parsed[0].toInteger()
+    def minor = parsed[1].toInteger()
+
+    // Namespace support was added in 7.3.0
+    if (major == 7 && minor >= 3) {
+        return true
+    }
+
+    return major >= 8
+}
+
 android {
-    compileSdkVersion safeExtGet('compileSdkVersion', 27)
+    if (supportsNamespace()) {
+        namespace "com.reactnative.googlefit"
+    } else {
+        sourceSets {
+            main {
+                manifest.srcFile "src/main/AndroidManifest.xml"
+            }
+        }
+    }
+    compileSdkVersion safeExtGet('compileSdkVersion', 28)
     // buildToolsVersion safeExtGet('buildToolsVersion', '27.0.3')
 
     compileOptions {
@@ -28,7 +50,7 @@ android {
 
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', 16)
-        targetSdkVersion safeExtGet('targetSdkVersion', 27)
+        targetSdkVersion safeExtGet('targetSdkVersion', 28)
         versionCode 1
         versionName "1.0"
     }
@@ -48,11 +70,19 @@ repositories {
 }
 
 dependencies {
+    def supportLibVersion = safeExtGet('supportLibVersion', null)
+    def androidXVersion = safeExtGet('androidXVersion', null)
+
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation('com.facebook.react:react-native:+') {
         exclude group: 'com.android.support'
     }
-    implementation "com.android.support:appcompat-v7:${safeExtGet('supportLibVersion', '27.0.0')}"
+    if (supportLibVersion && androidXVersion == null) {
+        implementation "com.android.support:appcompat-v7:$supportLibVersion"
+    } else {
+        def defaultAndroidXVersion = "1.+"
+        implementation "androidx.appcompat:appcompat:${safeExtGet(androidXVersion, defaultAndroidXVersion)}"
+    }
     implementation "com.google.android.gms:play-services-auth:${safeExtGet('authVersion', '+')}"
     implementation "com.google.android.gms:play-services-fitness:${safeExtGet('fitnessVersion', '+')}"
 }

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,0 +1,15 @@
+## For more details on how to configure your build environment visit
+# http://www.gradle.org/docs/current/userguide/build_environment.html
+#
+# Specifies the JVM arguments used for the daemon process.
+# The setting is particularly useful for tweaking memory settings.
+# Default value: -Xmx1024m -XX:MaxPermSize=256m
+# org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
+#
+# When configured, Gradle will run in incubating parallel mode.
+# This option should only be used with decoupled projects. More details, visit
+# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
+# org.gradle.parallel=true
+#Wed Oct 11 13:41:26 CEST 2023
+android.enableJetifier=true
+android.useAndroidX=true


### PR DESCRIPTION
Hi, I'm not used to this kind of PRs so please tell me if my change is wrong.
Jetifier being deprecated, we need to migrate libs to AndroidX:
<img width="890" alt="image" src="https://github.com/StasDoskalenko/react-native-google-fit/assets/16898357/a29b9d44-8259-40e0-be20-3a303cacb286">


- Use AndroidX by default but keep backwards compatibility with `supportLibVersion`.

- Bump sdk version to 28 (needed for AndroidX)