### PR TITLE
Improvement: Add Distance to saveWorkout, to match workout fetching.

### DIFF
--- a/android/src/main/java/com/reactnative/googlefit/ActivityHistory.java
+++ b/android/src/main/java/com/reactnative/googlefit/ActivityHistory.java
@@ -369,6 +369,23 @@ public class ActivityHistory {
             fitnessOptionsBuilder.addDataType(DataType.TYPE_STEP_COUNT_DELTA, FitnessOptions.ACCESS_WRITE);
         }
 
+        if (options.hasKey(DISTANCE_FIELD_NAME)) {
+            float distance = (float) options.getDouble(DISTANCE_FIELD_NAME);
+            DataSource distanceDataSource = createWorkoutDataSource(DataType.TYPE_DISTANCE_DELTA);
+
+            DataPoint distanceDataPoint = DataPoint.builder(distanceDataSource)
+                    .setTimeInterval(startTime, endTime, TimeUnit.MILLISECONDS)
+                    .setField(Field.FIELD_DISTANCE, distance)
+                    .build();
+
+            DataSet distanceDataSet = DataSet.builder(distanceDataSource)
+                    .add(distanceDataPoint)
+                    .build();
+
+            sessionInsertBuilder.addDataSet(distanceDataSet);
+            fitnessOptionsBuilder.addDataType(DataType.TYPE_DISTANCE_DELTA, FitnessOptions.ACCESS_WRITE);
+        }
+
         // add dataSet into session
         SessionInsertRequest insertRequest = sessionInsertBuilder.build();
 

--- a/index.android.d.ts
+++ b/index.android.d.ts
@@ -475,6 +475,7 @@ declare module 'react-native-google-fit' {
     calories?: number,
     steps?: number,
     intensity?: number,
+    distance?: number,
   }
 
   export type Granularity = {


### PR DESCRIPTION
Resolves #357 

# Background 
Save Workout did not include distance which is an odd api choice because fetch workout does include distance. For my own personal needs adding distance to workout saving was necessary and i imagine it will be valuable to other users as well. I did mention a notice of missing permissions somewhere in the code but i tested this code and it works as is. Modeled it after the way calories and intensity are optionally added into the save workout payload. 


Mention in comments about permission restriction
https://github.com/StasDoskalenko/react-native-google-fit/blob/master/android/src/main/java/com/reactnative/googlefit/ActivityHistory.java#L390
```
        // distance scope is missing here due to permission restriction
        // will be added in the future while distance is also available from saveWorkout()
```

# What Changed 
Updated `WorkoutSample` type to include optional distance number `distance?: number

```
  export type WorkoutSample = {
    startDate: string,
    endDate: string,
    activityType: ActivityType,
    sessionName: string,
    identifier: string,
    description?: string,
    calories?: number,
    steps?: number,
    intensity?: number,
 +    distance?: number,
  }
  ```
  
  Conditionally add this as a data set into the session Insert Builder similar to calories and intensity: 
  
  ```
  if (options.hasKey(DISTANCE_FIELD_NAME)) {
  ... 
    sessionInsertBuilder.addDataSet(distanceDataSet);
  ... 
  } 
  ```
  
  
  # How to test
  Submit a workout with distance, 
  Verify that reading the workout includes the same distance 
  Go to google fit app and verify it was stored with distance
 